### PR TITLE
Fix typo in login.commit

### DIFF
--- a/src/mstodo/handlers/login.py
+++ b/src/mstodo/handlers/login.py
@@ -58,7 +58,7 @@ def commit(args, modifier=None):
     manual_verification_url = re.search(r'localhost\S+', command)
 
     if manual_verification_url:
-        auth_status = auth.handle_authorization_url('http://' + manual_verification_url.group())
+        auth_status = auth.handle_authorisation_url('http://' + manual_verification_url.group())
 
         if auth_status is True:
             relaunch_alfred()


### PR DESCRIPTION
`handle_authorization_url` doesn't seem to be defined, I think this should be [`handle_authorisation_url`](https://github.com/johandebeurs/alfred-mstodo-workflow/blob/516f6d28d8d74c01736cdc9d7812714af522eb1e/src/mstodo/auth.py#L62) instead.